### PR TITLE
Implement /view endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,15 @@ const API_URL = 'https://krdict.korean.go.kr/api/search';
 const VIEW_URL = 'https://krdict.korean.go.kr/api/view';
 let API_KEY: string | null = null;
 const KEY_REMAPS: Record<string, string> = {
+    conju_info: 'conjugations',
+    der_info: 'derivativeInfo',
+    ref_info: 'referenceInfo',
+    rel_info: 'relatedInfo',
     sup_no: 'homomorphicNumber',
     sense: 'meaning',
+    sense_info: 'meaningInfo',
     sense_order: 'meaningOrder',
+    subsense_info: 'submeaningInfo',
     pos: 'partOfSpeech',
     word_grade: 'vocabularyGrade',
     trans_lang: 'language',
@@ -170,9 +176,8 @@ function getCleanJsonData(json: any): object {
         }
     }
 
-    // tslint:disable-next-line
-    for (let i = 0; i < rename.length; i++) {
-        const [container, oldKey, newKey] = rename[i];
+    for (const renamed of rename) {
+        const [container, oldKey, newKey] = renamed;
 
         container[newKey] = container[oldKey];
         delete container[oldKey];

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -10,6 +10,7 @@ import { SearchTargetType, mapSearchTargetType } from './value_types/search_targ
 import { SecondCategory } from './value_types/second_category';
 import { SubjectCategory, mapSubjectCategory } from './value_types/subject_category';
 import { TranslationLanguage, mapTranslationLanguage } from './value_types/translation_language';
+import { ViewMethod } from './value_types/view_method';
 import { VocabularyGrade, mapVocabularyGrade } from './value_types/vocabulary_grade';
 
 type ParametersValues = string | number | boolean | number[] | string[] | undefined;
@@ -41,6 +42,25 @@ interface Parameters extends ParametersProperties {
     meaningCategory?: MeaningCategory[];
     subjectCategory?: SubjectCategory[];
 }
+
+interface BaseViewParameters extends ParametersProperties {
+    key?: string;
+    viewMethod: ViewMethod;
+    shouldTranslate?: boolean;
+    translationLanguage?: TranslationLanguage | TranslationLanguage[];
+}
+
+interface WordInfoViewParameters extends BaseViewParameters {
+    query: string;
+    viewMethod: 'word_info';
+    homomorphicNumber?: number;
+}
+interface TargetCodeViewParameters extends BaseViewParameters {
+    targetCode: number;
+    viewMethod: 'target_code';
+}
+
+type ViewParameters = WordInfoViewParameters | TargetCodeViewParameters;
 
 interface ParameterMapperProperties {
     [property: string]: {
@@ -122,10 +142,13 @@ const parameterMapper: ParameterMapperProperties = {
         name: 'subject_cat',
         mapperFunction: mapSubjectCategory,
     },
+    viewMethod: {
+        name: 'method'
+    }
 };
 
 function booleanMapper(booleanValue: boolean) {
     return booleanValue ? 'y' : 'n';
 }
 
-export { Parameters, ParametersValues, parameterMapper };
+export { Parameters, ParametersValues, ViewParameters, parameterMapper };

--- a/src/value_types/view_method.ts
+++ b/src/value_types/view_method.ts
@@ -1,0 +1,3 @@
+type ViewMethod = 'word_info' | 'target_code';
+
+export { ViewMethod };


### PR DESCRIPTION
- Implemented the /view endpoint of the API. Separate parameter types are used for each view method, which are transformed into query parameters using `transformViewParameters`. Perhaps this function would fit better in `parameters.ts`?
- Fixed bug which would perform unnecessary snake-case fixes for remapped keys.
- Fixed bug which indexed using array values.