### PR TITLE
Increase timeout for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "tsc",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "tslint -p tsconfig.json",
-    "test": "mocha 'test' --require ts-node/register --recursive --exit"
+    "test": "mocha 'test' --require ts-node/register --recursive --exit --timeout 20000"
   },
   "author": "Fox Islam",
   "license": "ISC",


### PR DESCRIPTION
Requests to krdict's API take up to 10 seconds to complete which causes the default timeout on mocha (2 seconds) to be exceeded and the tests to fail. Increased the timeout to 20 seconds