### PR TITLE
Simplify result object

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,25 +22,23 @@ krdict.dictionarySearch({
 Which would ouput something like this:
 ```json
 {
-  "channel": {
-    ...
-    "item": [
-      {
-        "word": [ "나무" ],
-        "vocabularyGrade": [ "초급" ],
-        "partOfSpeech": [ "명사" ],
-        ...
-        "meaning": [
-          {
-            "meaningOrder": [ "1" ],
-            "definition": [ "단단한 줄기에 가지와 잎이 달린, 여러 해 동안 자라는 식물." ]
-          },
-          ...
-        ]
-      },
+  ...
+  "item": [
+    {
+      "word": "나무",
+      "vocabularyGrade": "초급",
+      "partOfSpeech": "명사",
       ...
-    ]
-  }
+      "meaning": [
+        {
+          "meaningOrder": 1,
+          "definition": "단단한 줄기에 가지와 잎이 달린, 여러 해 동안 자라는 식물."
+        },
+        ...
+      ]
+    },
+    ...
+  ]
 }
 ```
 
@@ -72,30 +70,28 @@ which are mapped to the parameter names and values expected by the krdict API:
 ```
 ```json
 {
-  "channel": {
-    ...
-    "item": [
-        {
-            "word": [ "나무" ],
-            "vocabularyGrade": [ "초급" ],
-            "partOfSpeech": [ "명사" ],
-            ...
-            "meaning": [
-                {
-                    "meaningOrder": [ "1" ],
-                    "definition": [ "단단한 줄기에 가지와 잎이 달린, 여러 해 동안 자라는 식물." ],
-                    "translation": [{
-                        "language": [ "영어" ],
-                        "word": [ "tree" ],
-                        "definition": [ "A plant with a hard stem, branches and leaves." ]
-                    }]
-                },
-                ...
-            ]
-        },
-        ...
-    ]
-  }
+  ...
+  "item": [
+      {
+          "word": "나무",
+          "vocabularyGrade": "초급",
+          "partOfSpeech": "명사",
+          ...
+          "meaning": [
+              {
+                  "meaningOrder": 1,
+                  "definition": "단단한 줄기에 가지와 잎이 달린, 여러 해 동안 자라는 식물.",
+                  "translation": [{
+                      "language": "영어",
+                      "word": "tree",
+                      "definition": "A plant with a hard stem, branches and leaves."
+                  }]
+              },
+              ...
+          ]
+      },
+      ...
+  ]
 }
 ```
 You can view a complete list of accepted parameters and their values on [the wiki page](https://github.com/Fox-Islam/krdict.js/wiki/Complete-list-of-parameters)

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -1,0 +1,21 @@
+function arrayConverter(container: any, key: string) {
+    if (Array.isArray(container[key])) {
+        return;
+    }
+
+    container[key] = [container[key]];
+}
+
+function numberConverter(container: any, key: string) {
+    container[key] = parseInt(container[key]);
+}
+
+function stringConverter(container: any, key: string) {
+    if (!Array.isArray(container[key])) {
+        return;
+    }
+
+    container[key] = container[key][0];
+}
+
+export { arrayConverter, numberConverter, stringConverter };

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ const CONVERTERS: Record<string, Function> = {
     total: numberConverter,
 };
 const KEY_REMAPS: Record<string, string> = {
+    channel: 'data',
     conju_info: 'conjugations',
     der_info: 'derivativeInfo',
     ref_info: 'referenceInfo',
@@ -122,10 +123,10 @@ function sendRequest(parameters: any, apiUrl: string = API_URL) {
                 }
                 jsonFromXml = parsedData;
             });
-            return {
-                requestParameters: parameters,
-                data: getCleanJsonData(jsonFromXml),
-            };
+
+            const result = getCleanJsonData(jsonFromXml);
+            result.requestParameters = parameters;
+            return result;
         })
         .catch((error) => {
             throw error;
@@ -169,7 +170,7 @@ function handleTypeConversion(container: any, key: string) {
     CONVERTERS[key](container, key);
 }
 
-function getCleanJsonData(json: any): object {
+function getCleanJsonData(json: any): any {
     const stack = [[json, null]];
     const rename: any[][] = [];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ const KEY_REMAPS: Record<string, string> = {
     trans_word: 'word',
     trans_dfn: 'definition',
 };
-const XML_PARSER = new Parser({explicitArray: false});
+const XML_PARSER = new Parser({explicitArray: false, trim: true});
 
 function setKey(key: string) {
     API_KEY = key;
@@ -132,17 +132,6 @@ function sendRequest(parameters: any, apiUrl: string = API_URL) {
         });
 }
 
-function handleTabAndNewline(container: any, key: string) {
-    const elem = container[key];
-
-    if (Array.isArray(elem) && elem.length === 1 && typeof elem[0] === 'string') {
-        // this branch can be removed when explicitArray option is used
-        elem[0] = elem[0].trim();
-    } else if (typeof elem === 'string') {
-        container[key] = elem.trim();
-    }
-}
-
 function handleRemaps(container: any, key: string, rename: any[][]) {
     if (KEY_REMAPS[key] === undefined) {
         return;
@@ -189,7 +178,6 @@ function getCleanJsonData(json: any): object {
         let [elem, key] = stack.pop()!;
 
         if (key !== null) {
-            handleTabAndNewline(elem, key);
             handleRemaps(elem, key, rename);
             handleSnakeCase(elem, key, rename);
             handleTypeConversion(elem, key);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { Parser } from 'xml2js';
 
 import { parameterMapper, Parameters, ParametersValues, ViewParameters } from './parameters';
-import { arrayConverter, numberConverter, stringConverter } from './converters'
+import { arrayConverter, numberConverter, stringConverter } from './converters';
 
 const API_URL = 'https://krdict.korean.go.kr/api/search';
 const VIEW_URL = 'https://krdict.korean.go.kr/api/view';
@@ -14,6 +14,7 @@ const CONVERTERS: Record<string, Function> = {
     error_code: numberConverter,
     example_info: arrayConverter,
     item: arrayConverter,
+    link_target_code: numberConverter,
     multimedia_info: arrayConverter,
     num: numberConverter,
     original_language_info: arrayConverter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ const KEY_REMAPS: Record<string, string> = {
     der_info: 'derivativeInfo',
     ref_info: 'referenceInfo',
     rel_info: 'relatedInfo',
-    sup_no: 'homomorphicNumber',
+    sup_no: 'homographNumber',
     sense: 'meaning',
     sense_info: 'meaningInfo',
     sense_order: 'meaningOrder',
@@ -92,8 +92,7 @@ function transformViewParameters(parameters: ViewParameters): Parameters {
 
     if (parameters.viewMethod === 'word_info') {
         if (parameters.hasOwnProperty('query')) {
-            const homomorphNum = parameters.homomorphicNumber !== undefined ? parameters.homomorphicNumber : 0;
-            parameters.query += homomorphNum;
+            parameters.query += parameters.homographNumber ?? 0;
         }
     } else if (parameters.hasOwnProperty('targetCode')) {
         parameters.query = parameters.targetCode.toString();

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -39,7 +39,7 @@ interface Parameters extends ParametersProperties {
     multimediaInformation?: MultimediaInformation | MultimediaInformation[];
     minNumberOfSyllables?: number;
     maxNumberOfSyllables?: number;
-    meaningCategory?: MeaningCategory | MeaningCategory[];
+    meaningCategory?: MeaningCategory;
     subjectCategory?: SubjectCategory | SubjectCategory[];
 }
 

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -53,7 +53,7 @@ interface BaseViewParameters extends ParametersProperties {
 interface WordInfoViewParameters extends BaseViewParameters {
     query: string;
     viewMethod: 'word_info';
-    homomorphicNumber?: number;
+    homographNumber?: number;
 }
 interface TargetCodeViewParameters extends BaseViewParameters {
     targetCode: number;

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -1,4 +1,4 @@
-import { FirstCategory } from './value_types/first_category';
+import { FirstCategory, mapFirstCategory } from './value_types/first_category';
 import { mapSearchTarget, SearchTarget } from './value_types/search_target';
 import { mapSortMethod, SortMethod } from './value_types/sort_method';
 import { MeaningCategory, mapMeaningCategory } from './value_types/meaning_category';
@@ -7,7 +7,7 @@ import { PartOfSpeech, mapPartOfSpeech } from './value_types/part_of_speech';
 import { TargetLanguage, mapTargetLanguage } from './value_types/target_language';
 import { SearchMethod } from './value_types/search_method';
 import { SearchTargetType, mapSearchTargetType } from './value_types/search_target_type';
-import { SecondCategory } from './value_types/second_category';
+import { mapSecondCategory, SecondCategory } from './value_types/second_category';
 import { SubjectCategory, mapSubjectCategory } from './value_types/subject_category';
 import { TranslationLanguage, mapTranslationLanguage } from './value_types/translation_language';
 import { ViewMethod } from './value_types/view_method';
@@ -32,15 +32,15 @@ interface Parameters extends ParametersProperties {
     searchTargetType?: SearchTargetType;
     targetLanguage?: TargetLanguage;
     searchMethod?: SearchMethod;
-    firstCategory?: FirstCategory[];
-    secondCategory?: SecondCategory[];
-    vocabularyGrade?: VocabularyGrade[];
-    partOfSpeech?: PartOfSpeech[];
-    multimediaInformation?: MultimediaInformation[];
+    firstCategory?: FirstCategory | FirstCategory[];
+    secondCategory?: SecondCategory | SecondCategory[];
+    vocabularyGrade?: VocabularyGrade | VocabularyGrade[];
+    partOfSpeech?: PartOfSpeech | PartOfSpeech[];
+    multimediaInformation?: MultimediaInformation | MultimediaInformation[];
     minNumberOfSyllables?: number;
     maxNumberOfSyllables?: number;
-    meaningCategory?: MeaningCategory[];
-    subjectCategory?: SubjectCategory[];
+    meaningCategory?: MeaningCategory | MeaningCategory[];
+    subjectCategory?: SubjectCategory | SubjectCategory[];
 }
 
 interface BaseViewParameters extends ParametersProperties {
@@ -112,9 +112,11 @@ const parameterMapper: ParameterMapperProperties = {
     },
     firstCategory: {
         name: 'type1',
+        mapperFunction: mapFirstCategory,
     },
     secondCategory: {
         name: 'type2',
+        mapperFunction: mapSecondCategory,
     },
     vocabularyGrade: {
         name: 'level',

--- a/src/value_types/first_category.ts
+++ b/src/value_types/first_category.ts
@@ -1,3 +1,10 @@
 type FirstCategory = 'all' | 'word' | 'phrase' | 'expression';
 
-export { FirstCategory };
+function mapFirstCategory(input: FirstCategory | FirstCategory[]): string {
+    if (typeof input === 'string') {
+        return input;
+    }
+    return input.join(',');
+}
+
+export { FirstCategory, mapFirstCategory };

--- a/src/value_types/meaning_category.ts
+++ b/src/value_types/meaning_category.ts
@@ -311,10 +311,13 @@ type MeaningCategory =
     | 'concept> person'
     | 'area';
 
-function mapMeaningCategory(input: MeaningCategory[]): number[] {
+function mapMeaningCategory(input: MeaningCategory[]): number | string {
+    if (typeof input === 'string') {
+        return mapKey[input];
+    }
     return input.map((transLang) => {
         return mapKey[transLang];
-    });
+    }).join(',');
 }
 
 export { MeaningCategory, mapMeaningCategory };

--- a/src/value_types/meaning_category.ts
+++ b/src/value_types/meaning_category.ts
@@ -311,13 +311,8 @@ type MeaningCategory =
     | 'concept> person'
     | 'area';
 
-function mapMeaningCategory(input: MeaningCategory[]): number | string {
-    if (typeof input === 'string') {
-        return mapKey[input];
-    }
-    return input.map((transLang) => {
-        return mapKey[transLang];
-    }).join(',');
+function mapMeaningCategory(input: MeaningCategory): number {
+    return mapKey[input];
 }
 
 export { MeaningCategory, mapMeaningCategory };

--- a/src/value_types/multimedia_information.ts
+++ b/src/value_types/multimedia_information.ts
@@ -10,10 +10,13 @@ const mapKey = {
 
 type MultimediaInformation = 'all' | 'photo' | 'illustration' | 'video' | 'animation' | 'sound' | 'none';
 
-function mapMultimediaInformation(input: MultimediaInformation[]): number[] {
+function mapMultimediaInformation(input: MultimediaInformation | MultimediaInformation[]): number | string {
+    if (typeof input === 'string') {
+        return mapKey[input];
+    }
     return input.map((transLang) => {
         return mapKey[transLang];
-    });
+    }).join(',');
 }
 
 export { MultimediaInformation, mapMultimediaInformation };

--- a/src/value_types/part_of_speech.ts
+++ b/src/value_types/part_of_speech.ts
@@ -34,10 +34,13 @@ type PartOfSpeech =
     | 'ending'
     | 'none';
 
-function mapPartOfSpeech(input: PartOfSpeech[]): number[] {
+function mapPartOfSpeech(input: PartOfSpeech | PartOfSpeech[]): number | string {
+    if (typeof input === 'string') {
+        return mapKey[input];
+    }
     return input.map((transLang) => {
         return mapKey[transLang];
-    });
+    }).join(',');
 }
 
 export { PartOfSpeech, mapPartOfSpeech };

--- a/src/value_types/second_category.ts
+++ b/src/value_types/second_category.ts
@@ -1,3 +1,10 @@
 type SecondCategory = 'all' | 'native' | 'chinese' | 'loanword' | 'hybrid';
 
-export { SecondCategory };
+function mapSecondCategory(input: SecondCategory | SecondCategory[]): string {
+    if (typeof input === 'string') {
+        return input;
+    }
+    return input.join(',');
+}
+
+export { SecondCategory, mapSecondCategory };

--- a/src/value_types/subject_category.ts
+++ b/src/value_types/subject_category.ts
@@ -217,9 +217,12 @@ type SubjectCategory =
     | 'religion'
     | 'philosophy and ethics';
 
-function mapSubjectCategory(input: SubjectCategory[]): number[] {
+function mapSubjectCategory(input: SubjectCategory[]): number | string {
+    if (typeof input === 'string') {
+        return mapKey[input];
+    }
     return input.map((transLang) => {
         return mapKey[transLang];
-    });
+    }).join(',');
 }
 export { SubjectCategory, mapSubjectCategory };

--- a/src/value_types/target_language.ts
+++ b/src/value_types/target_language.ts
@@ -1,9 +1,8 @@
 const mapKey = {
     all: 0,
-    'native language': 1,
-    chinese: 2,
-    'chinese (simplified)': 2,
-    unclear: 3,
+    'native word': 1,
+    'sino-korean': 2,
+    unknown: 3,
     english: 4,
     greek: 5,
     dutch: 6,
@@ -20,8 +19,7 @@ const mapKey = {
     vietnamese: 17,
     bulgarian: 18,
     sanskrit: 19,
-    servo: 20,
-    croat: 20,
+    'serbo-croatian': 20,
     swahili: 21,
     swedish: 22,
     arabic: 23,
@@ -32,7 +30,7 @@ const mapKey = {
     italian: 28,
     indonesian: 29,
     japanese: 30,
-    'chinese (traditional)': 31,
+    chinese: 31,
     czech: 32,
     cambodian: 33,
     quechua: 34,
@@ -55,10 +53,9 @@ const mapKey = {
 
 type TargetLanguage =
     | 'all'
-    | 'native language'
-    | 'chinese'
-    | 'chinese (simplified)'
-    | 'unclear'
+    | 'native word'
+    | 'sino-korean'
+    | 'unknown'
     | 'english'
     | 'greek'
     | 'dutch'
@@ -75,8 +72,7 @@ type TargetLanguage =
     | 'vietnamese'
     | 'bulgarian'
     | 'sanskrit'
-    | 'servo'
-    | 'croat'
+    | 'serbo-croatian'
     | 'swahili'
     | 'swedish'
     | 'arabic'
@@ -87,7 +83,7 @@ type TargetLanguage =
     | 'italian'
     | 'indonesian'
     | 'japanese'
-    | 'chinese (traditional)'
+    | 'chinese'
     | 'czech'
     | 'cambodian'
     | 'quechua'

--- a/src/value_types/translation_language.ts
+++ b/src/value_types/translation_language.ts
@@ -25,13 +25,13 @@ type TranslationLanguage =
     | 'indonesian'
     | 'russian';
 
-function mapTranslationLanguage(input: TranslationLanguage | TranslationLanguage[]): number | number[] {
+function mapTranslationLanguage(input: TranslationLanguage | TranslationLanguage[]): number | string {
     if (typeof input === 'string') {
         return mapKey[input];
     }
     return input.map((transLang) => {
         return mapKey[transLang];
-    });
+    }).join(',');
 }
 
 export { TranslationLanguage, mapTranslationLanguage };

--- a/src/value_types/vocabulary_grade.ts
+++ b/src/value_types/vocabulary_grade.ts
@@ -10,10 +10,13 @@ const mapKey = {
 
 type VocabularyGrade = 'all' | 'level1' | 'level2' | 'level3' | 'beginner' | 'intermediate' | 'advanced';
 
-function mapVocabularyGrade(input: VocabularyGrade[]): string[] {
+function mapVocabularyGrade(input: VocabularyGrade | VocabularyGrade[]): string {
+    if (typeof input === 'string') {
+        return mapKey[input];
+    }
     return input.map((grade) => {
         return mapKey[grade];
-    });
+    }).join(',');
 }
 
 export { VocabularyGrade, mapVocabularyGrade };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -89,3 +89,31 @@ describe('When searching via the krdict API using the "dictionarySearch" functio
         expect(getNthItem(responseData, 0).meaning[2].definition).to.eql('불을 때기 위해 베어 놓은 나무의 줄기나 가지.');
     });
 });
+
+describe('When retrieving data via the krdict API using the "dictionaryView" function', function () {
+    it('Should return results when searching with word_info view method', async function() {
+        const response = await krdict.dictionaryView({
+            query: '나무',
+            viewMethod: 'word_info'
+        });
+        const responseData = response.data;
+        expect(responseData.channel).to.not.be.null;
+        const item = getNthItem(responseData, 0);
+        expect(item.targetCode).to.eql(32750);
+        expect(item.wordInfo.word).to.eql('나무');
+        expect(responseData.channel.total).to.eql(1);
+    });
+
+    it('Should return results when searching with target_code view method', async function () {
+        const response = await krdict.dictionaryView({
+            targetCode: 32750,
+            viewMethod: 'target_code'
+        });
+        const responseData = response.data;
+        expect(responseData.channel).to.not.be.null;
+        const item = getNthItem(responseData, 0);
+        expect(item.targetCode).to.eql(32750);
+        expect(item.wordInfo.word).to.eql('나무');
+        expect(responseData.channel.total).to.eql(1);
+    });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,26 +9,26 @@ function getNthItem(responseData, n) {
     return responseData.channel.item[n];
 }
 
-describe('When searching via the krdict API using the "searchDictionary" function', function () {
+describe('When searching via the krdict API using the "dictionarySearch" function', function () {
     it('Should return results when passing in basic parameters', async function () {
         const response = await krdict.dictionarySearch({
             query: '나무'
         });
         const responseData = response.data;
         expect(responseData.channel).to.not.be.null;
-        expect(getNthItem(responseData, 0).word).to.eql(['나무']);
-        expect(getNthItem(responseData, 1).word).to.eql(['나무라다']);
-        expect(getNthItem(responseData, 2).word).to.eql(['나무꾼']);
-        expect(getNthItem(responseData, 3).word).to.eql(['나무람']);
-        expect(getNthItem(responseData, 4).word).to.eql(['나무배']);
-        expect(getNthItem(responseData, 5).word).to.eql(['나무뿌리']);
-        expect(getNthItem(responseData, 6).word).to.eql(['나무숲']);
-        expect(getNthItem(responseData, 7).word).to.eql(['나무아미타불']);
-        expect(getNthItem(responseData, 8).word).to.eql(['나무아미타불']);
-        expect(getNthItem(responseData, 9).word).to.eql(['나무저']);
-        expect(responseData.channel.num).to.eql(['10']);
-        expect(responseData.channel.start).to.eql(['1']);
-        expect(responseData.channel.total).to.eql(['53']);
+        expect(getNthItem(responseData, 0).word).to.eql('나무');
+        expect(getNthItem(responseData, 1).word).to.eql('나무라다');
+        expect(getNthItem(responseData, 2).word).to.eql('나무꾼');
+        expect(getNthItem(responseData, 3).word).to.eql('나무람');
+        expect(getNthItem(responseData, 4).word).to.eql('나무배');
+        expect(getNthItem(responseData, 5).word).to.eql('나무뿌리');
+        expect(getNthItem(responseData, 6).word).to.eql('나무숲');
+        expect(getNthItem(responseData, 7).word).to.eql('나무아미타불');
+        expect(getNthItem(responseData, 8).word).to.eql('나무아미타불');
+        expect(getNthItem(responseData, 9).word).to.eql('나무저');
+        expect(responseData.channel.num).to.eql(10);
+        expect(responseData.channel.start).to.eql(1);
+        expect(responseData.channel.total).to.eql(53);
     });
 
     it('Should start at correct index when passing in "searchStartIndex" parameter', async function () {
@@ -38,7 +38,7 @@ describe('When searching via the krdict API using the "searchDictionary" functio
         });
         const responseData = response.data;
         expect(responseData.channel).to.not.be.null;
-        expect(responseData.channel.start).to.eql(['5']);
+        expect(responseData.channel.start).to.eql(5);
     });
 
     it('Should return correct number of results when passing in "numberOfResults" parameter', async function () {
@@ -48,7 +48,7 @@ describe('When searching via the krdict API using the "searchDictionary" functio
         });
         const responseData = response.data;
         expect(responseData.channel.item).to.be.an('array').of.length(15);
-        expect(responseData.channel.num).to.eql(['15']);
+        expect(responseData.channel.num).to.eql(15);
     });
 
     it('Should return correctly sorted data when passing in "sortMethod" parameter', async function () {
@@ -57,20 +57,10 @@ describe('When searching via the krdict API using the "searchDictionary" functio
             sortMethod: "popular"
         });
         const responseData = response.data;
-        expect(getNthItem(responseData, 0).word).to.eql(['나무']);
-        expect(getNthItem(responseData, 1).word).to.eql(['나무라다']);
-        expect(getNthItem(responseData, 2).word).to.eql(['나무하다']);
-        expect(getNthItem(responseData, 3).word).to.eql(['나무아미타불']);
-    });
-
-    it('Should return correct number of results when passing in "numberOfResults" parameter', async function () {
-        const response = await krdict.dictionarySearch({
-            query: '나무',
-            numberOfResults: 15
-        });
-        const responseData = response.data;
-        expect(responseData.channel.item).to.be.an('array').of.length(15);
-        expect(responseData.channel.num).to.eql(['15']);
+        expect(getNthItem(responseData, 0).word).to.eql('나무');
+        expect(getNthItem(responseData, 1).word).to.eql('나무라다');
+        expect(getNthItem(responseData, 2).word).to.eql('나무하다');
+        expect(getNthItem(responseData, 3).word).to.eql('나무아미타불');
     });
 
     it('Should search in correct target when passing in "searchTarget" parameter', async function () {
@@ -80,8 +70,8 @@ describe('When searching via the krdict API using the "searchDictionary" functio
         });
         const responseData = response.data;
         responseData.channel.item.forEach((item) => {
-            expect(item.example).to.be.an('array');
-            expect(item.example[0]).to.contain('나무');
+            expect(item.example).to.be.a('string');
+            expect(item.example).to.contain('나무');
         });
     });
 
@@ -94,8 +84,8 @@ describe('When searching via the krdict API using the "searchDictionary" functio
         const responseData = response.data;
         expect(responseData.channel.item).to.be.an('array').of.length(1);
         expect(getNthItem(responseData, 0).meaning).to.be.an('array').of.length(3);
-        expect(getNthItem(responseData, 0).meaning[0].definition).to.eql(['단단한 줄기에 가지와 잎이 달린, 여러 해 동안 자라는 식물.']);
-        expect(getNthItem(responseData, 0).meaning[1].definition).to.eql(['집이나 가구 등을 만드는 데 사용하는 재목.']);
-        expect(getNthItem(responseData, 0).meaning[2].definition).to.eql(['불을 때기 위해 베어 놓은 나무의 줄기나 가지.']);
+        expect(getNthItem(responseData, 0).meaning[0].definition).to.eql('단단한 줄기에 가지와 잎이 달린, 여러 해 동안 자라는 식물.');
+        expect(getNthItem(responseData, 0).meaning[1].definition).to.eql('집이나 가구 등을 만드는 데 사용하는 재목.');
+        expect(getNthItem(responseData, 0).meaning[2].definition).to.eql('불을 때기 위해 베어 놓은 나무의 줄기나 가지.');
     });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,7 +6,7 @@ const krdict = require('./../src/index');
 krdict.setKey(process.env.KRDICT_KEY);
 
 function getNthItem(responseData, n) {
-    return responseData.channel.item[n];
+    return responseData.item[n];
 }
 
 describe('When searching via the krdict API using the "dictionarySearch" function', function () {
@@ -15,7 +15,7 @@ describe('When searching via the krdict API using the "dictionarySearch" functio
             query: '나무'
         });
         const responseData = response.data;
-        expect(responseData.channel).to.not.be.null;
+        expect(responseData).to.not.be.null;
         expect(getNthItem(responseData, 0).word).to.eql('나무');
         expect(getNthItem(responseData, 1).word).to.eql('나무라다');
         expect(getNthItem(responseData, 2).word).to.eql('나무꾼');
@@ -26,9 +26,9 @@ describe('When searching via the krdict API using the "dictionarySearch" functio
         expect(getNthItem(responseData, 7).word).to.eql('나무아미타불');
         expect(getNthItem(responseData, 8).word).to.eql('나무아미타불');
         expect(getNthItem(responseData, 9).word).to.eql('나무저');
-        expect(responseData.channel.num).to.eql(10);
-        expect(responseData.channel.start).to.eql(1);
-        expect(responseData.channel.total).to.eql(53);
+        expect(responseData.num).to.eql(10);
+        expect(responseData.start).to.eql(1);
+        expect(responseData.total).to.eql(53);
     });
 
     it('Should start at correct index when passing in "searchStartIndex" parameter', async function () {
@@ -37,8 +37,8 @@ describe('When searching via the krdict API using the "dictionarySearch" functio
             searchStartIndex: 5
         });
         const responseData = response.data;
-        expect(responseData.channel).to.not.be.null;
-        expect(responseData.channel.start).to.eql(5);
+        expect(responseData).to.not.be.null;
+        expect(responseData.start).to.eql(5);
     });
 
     it('Should return correct number of results when passing in "numberOfResults" parameter', async function () {
@@ -47,8 +47,8 @@ describe('When searching via the krdict API using the "dictionarySearch" functio
             numberOfResults: 15
         });
         const responseData = response.data;
-        expect(responseData.channel.item).to.be.an('array').of.length(15);
-        expect(responseData.channel.num).to.eql(15);
+        expect(responseData.item).to.be.an('array').of.length(15);
+        expect(responseData.num).to.eql(15);
     });
 
     it('Should return correctly sorted data when passing in "sortMethod" parameter', async function () {
@@ -69,7 +69,7 @@ describe('When searching via the krdict API using the "dictionarySearch" functio
             searchTarget: 'example'
         });
         const responseData = response.data;
-        responseData.channel.item.forEach((item) => {
+        responseData.item.forEach((item) => {
             expect(item.example).to.be.a('string');
             expect(item.example).to.contain('나무');
         });
@@ -82,7 +82,7 @@ describe('When searching via the krdict API using the "dictionarySearch" functio
             detailedSearch: true,
         });
         const responseData = response.data;
-        expect(responseData.channel.item).to.be.an('array').of.length(1);
+        expect(responseData.item).to.be.an('array').of.length(1);
         expect(getNthItem(responseData, 0).meaning).to.be.an('array').of.length(3);
         expect(getNthItem(responseData, 0).meaning[0].definition).to.eql('단단한 줄기에 가지와 잎이 달린, 여러 해 동안 자라는 식물.');
         expect(getNthItem(responseData, 0).meaning[1].definition).to.eql('집이나 가구 등을 만드는 데 사용하는 재목.');
@@ -97,11 +97,11 @@ describe('When retrieving data via the krdict API using the "dictionaryView" fun
             viewMethod: 'word_info'
         });
         const responseData = response.data;
-        expect(responseData.channel).to.not.be.null;
+        expect(responseData).to.not.be.null;
         const item = getNthItem(responseData, 0);
         expect(item.targetCode).to.eql(32750);
         expect(item.wordInfo.word).to.eql('나무');
-        expect(responseData.channel.total).to.eql(1);
+        expect(responseData.total).to.eql(1);
     });
 
     it('Should return results when searching with target_code view method', async function () {
@@ -110,10 +110,10 @@ describe('When retrieving data via the krdict API using the "dictionaryView" fun
             viewMethod: 'target_code'
         });
         const responseData = response.data;
-        expect(responseData.channel).to.not.be.null;
+        expect(responseData).to.not.be.null;
         const item = getNthItem(responseData, 0);
         expect(item.targetCode).to.eql(32750);
         expect(item.wordInfo.word).to.eql('나무');
-        expect(responseData.channel.total).to.eql(1);
+        expect(responseData.total).to.eql(1);
     });
 });


### PR DESCRIPTION
### Features
- Added the `explicitArray: false` option to the parser.
- Added type conversions to account for expected array types and numbers.
- Added the `trim: true` option to the parser.
  - Removed `handleTabAndNewline`; this is now handled by the trim option.
- Modified the result structure.
  - `requestParameters` is now added directly to the result.
  - `channel` is renamed to `data` to match the existing key.
- Updated existing tests to reflect result simplification.
- Added some simple tests for dictionaryView (perhaps not enough).

### Fixes
- Fixed multiple select bug for various types:
  - TranslationLanguage
  - FirstCategory
  - SecondCategory
  - VocabularyGrade
  - PartOfSpeech
  - MultimediaInfo
  - MeaningCategory *(edit: as it turns out, the API only accepts one value for this type)*
  - SubjectCategory
- Changed `homomorphicNum` to `homographNum` for clarity.
  - I think that name came about from a mistranslation on my part at some point—sorry!

### Suggestions
1. Changing the aliases of `firstCategory` (type1) and `secondCategory` (type2). These names aren't particularly descriptive (although better than "type1" and "type2"), and I figure a major version increase is the perfect time to change them. Instead of `firstCategory`, `classification` may be a better fit (this is the word used on the website's advanced search for the same option). `secondCategory` is technically "classification 2", but `originType` may be a more descriptive name for it.
2. Changing the aliases of `searchTarget` (part) and `searchTargetType` (target). The documentation isn't very helpful for figuring out the difference between these, considering the descriptions of both translate loosely to "search target", but checking the query parameters in the website's URL shows that 'part' corresponds to `searchType` in the query parameters. 'target', on the other hand, corresponds to the search target in the advanced search; `searchTarget` would be a better name for *this* parameter.

TL;DR (I completely understand if you skipped to this, that was a wordy explanation), I'd like to rename these parameters:
- `firstCategory` → `classification`
- `secondCategory` → `originType`
- `searchTarget` → `searchType`
- `searchTargetType` → `searchTarget`

I'll go ahead and add a commit fixing the array problem and hold off on the renaming until I hear back about it.
@Fox-Islam 